### PR TITLE
Small literate-unitb-config tweaks

### DIFF
--- a/literate-unitb-config/Z3/Version.hs
+++ b/literate-unitb-config/Z3/Version.hs
@@ -74,7 +74,8 @@ z3_installed = do
     else do
             let ps = L.split ":" path
             forM ps (doesFileExist . (`combine` "z3"))
-    return $ or xs
+    z3_bin <- doesFileExist z3_path
+    return $ or (z3_bin : xs)
 
 config :: Lens' ConfigParser Z3Config
 config = lensOf $ Z3Config 

--- a/literate-unitb-config/app/Options.hs
+++ b/literate-unitb-config/app/Options.hs
@@ -11,6 +11,9 @@ import Data.Monoid
 
 import Options.Applicative 
 
+import System.Directory
+
+import Utilities.Config
 import Z3.Version
 
 data SetOptions = SetOptions
@@ -48,6 +51,8 @@ rewriteConfig f = do
     (fn,cp) <- getConfigFile
     _ <- evaluate cp
     let c' = f $ cp^.config
+    homeSetting <- homeSettingPath
+    createDirectoryIfMissing False homeSetting
     writeFile fn $ to_string $ cp & config .~ c'
     putStrLn "set the options to:"
     print c'


### PR DESCRIPTION
Z3.Version: include `z3_path` when checking existence of z3 in `z3_installed`.

unitb-option: create the `homeSettingPath` directory if it doesn't exist.