### PR TITLE
unitb-config revamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -222,7 +222,6 @@ jobs:
     compiler: ": #stack default"
     addons: {apt: {packages: [libgmp-dev]}}
     script: 
-      - unitb-option --capacity $Z3_CAPACITY --hard-timeout $Z3_HARD_TIMEOUT --default-timeout $Z3_DEFAULT_TIMEOUT
       - travis_long stack --no-terminal $ARGS test literate-unitb-verifier --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-docs --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-synthesis --bench --no-run-benchmarks
@@ -232,7 +231,6 @@ jobs:
     compiler: ": #stack 7.10.2"
     addons: {apt: {packages: [libgmp-dev]}}
     script: 
-      - unitb-option --capacity $Z3_CAPACITY --hard-timeout $Z3_HARD_TIMEOUT --default-timeout $Z3_DEFAULT_TIMEOUT
       - travis_long stack --no-terminal $ARGS test literate-unitb-verifier --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-docs --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-synthesis --bench --no-run-benchmarks
@@ -242,7 +240,6 @@ jobs:
     compiler: ": #stack 7.10.3"
     addons: {apt: {packages: [libgmp-dev]}}
     script: 
-      - unitb-option --capacity $Z3_CAPACITY --hard-timeout $Z3_HARD_TIMEOUT --default-timeout $Z3_DEFAULT_TIMEOUT
       - travis_long stack --no-terminal $ARGS test literate-unitb-verifier --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-docs --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-synthesis --bench --no-run-benchmarks
@@ -252,7 +249,6 @@ jobs:
     compiler: ": #stack 8.0.1"
     addons: {apt: {packages: [libgmp-dev]}}
     script: 
-      - unitb-option --capacity $Z3_CAPACITY --hard-timeout $Z3_HARD_TIMEOUT --default-timeout $Z3_DEFAULT_TIMEOUT
       - travis_long stack --no-terminal $ARGS test literate-unitb-verifier --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-docs --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-synthesis --bench --no-run-benchmarks
@@ -262,7 +258,6 @@ jobs:
     compiler: ": #stack 8.0.2"
     addons: {apt: {packages: [libgmp-dev]}}
     script: 
-      - unitb-option --capacity $Z3_CAPACITY --hard-timeout $Z3_HARD_TIMEOUT --default-timeout $Z3_DEFAULT_TIMEOUT
       - travis_long stack --no-terminal $ARGS test literate-unitb-verifier --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-docs --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-synthesis --bench --no-run-benchmarks
@@ -272,7 +267,6 @@ jobs:
     compiler: ": #stack nightly"
     addons: {apt: {packages: [libgmp-dev]}}
     script: 
-      - unitb-option --capacity $Z3_CAPACITY --hard-timeout $Z3_HARD_TIMEOUT --default-timeout $Z3_DEFAULT_TIMEOUT
       - travis_long stack --no-terminal $ARGS test literate-unitb-verifier --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-docs --bench --no-run-benchmarks
       - travis_long stack --no-terminal $ARGS test literate-unitb-synthesis --bench --no-run-benchmarks
@@ -313,13 +307,6 @@ before_install:
   fi
 - export PATH="$HOME/z3:$PATH"
 - z3 -h
-# 
-- Z3_CONFIG="$HOME/Literate Unit-B"
-- mkdir "$Z3_CONFIG" || echo ""
-- echo [DEFAULT] > "$Z3_CONFIG/z3.config"
-- echo "capacity = 8" >> "$Z3_CONFIG/z3.config"
-- echo "timeout = 30" >> "$Z3_CONFIG/z3.config"
-- cat "$Z3_CONFIG/z3.config"
 # Deploy anti-timeout weapon
 - mkdir $HOME/scripts || echo ""
 - export PATH="$HOME/scripts:$PATH"
@@ -352,6 +339,7 @@ install:
 - if [ -f configure.ac ]; then autoreconf -i; fi
 - travis_long stack --no-terminal --install-ghc $ARGS install literate-unitb-logic literate-unitb-verifier literate-unitb-docs literate-unitb-synthesis literate-unitb-cli --only-dependencies --test
 - travis_long stack --no-terminal --install-ghc $ARGS install literate-unitb-config
+- unitb-config --capacity $Z3_CAPACITY --hard-timeout $Z3_HARD_TIMEOUT --default-timeout $Z3_DEFAULT_TIMEOUT
 - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
 # - |
 #   set -ex
@@ -422,7 +410,7 @@ before_deploy:
   - mkdir release/literate-unitb/sty
   - cp Tests/*.sty release/literate-unitb/sty/
   - cp $HOME/.local/bin/unitb release/unitb/
-  - cp $HOME/.local/bin/unitb-option release/unitb/
+  - cp $HOME/.local/bin/unitb-config release/unitb/
   - cp $HOME/z3/z3 release/unitb/
   - echo zip -r $HOME/`unitb-zip-name $TRAVIS_OS_NAME`.zip 
   - ls release

--- a/literate-unitb-config/Data/Bidirectional.hs
+++ b/literate-unitb-config/Data/Bidirectional.hs
@@ -47,13 +47,13 @@ instance Document Object where
         parseMaybe parseJSON v
 
 field :: (Document doc,ToJSON a,FromJSON a)
-       => String -> (b -> a)
-       -> BiParser Maybe b doc a
+      => String -> (b -> a)
+      -> BiParser Maybe b doc a
 field k f = BiParser (makeNode k . f) (lookupDoc k)
 
 fieldWith :: (Document doc,Applicative f,Eq a,ToJSON a,FromJSON a)
-           => String -> a -> (c -> a)
-           -> BiParser f c doc a
+          => String -> a -> (c -> a)
+          -> BiParser f c doc a
 fieldWith k def f = BiParser
             (\x doc -> 
                     let x' = f x in

--- a/literate-unitb-config/Data/Bidirectional.hs
+++ b/literate-unitb-config/Data/Bidirectional.hs
@@ -21,9 +21,6 @@ instance (Applicative f) => Applicative (BiParser f a b) where
         (\x -> f0 x . f1 x) 
         (\x -> g0 x <*> g1 x)
 
--- instance Profunctor (BiParser a) where
---     dimap f g (BiParser p q) = BiParser (_.p) (fmap g.q.f)
-
 lensOf :: BiParser Identity a s a
        -> Lens' s a
 lensOf (BiParser f g) = lens (runIdentity . g) (\x i -> f i x)
@@ -38,7 +35,6 @@ traverseOf :: s
            -> Traversal' s a
 traverseOf def (BiParser f g) h x =
     (\i -> f i def) <$> h (runIdentity $ g x)
-    -- f <$> h (runIdentity $ g x) <*> pure def
 
 class Document a where
     makeNode :: (ToJSON b) => String -> b -> a -> a

--- a/literate-unitb-config/Z3/Version.hs
+++ b/literate-unitb-config/Z3/Version.hs
@@ -85,9 +85,9 @@ z3_installed = do
 config :: Lens' Object Z3Config
 config = lensOf $ Z3Config 
         <$> fieldWith "z3" "z3_path" (view z3Path)
-        <*> fieldWith' 20 "timeout" (view z3Timeout)
-        <*> fieldWith' 3000 "default_timeout" (view z3DefaultTimeout)
-        <*> fieldWith' 32 "capacity" (view capacity)
+        <*> fieldWith 20 "timeout" (view z3Timeout)
+        <*> fieldWith 3000 "default_timeout" (view z3DefaultTimeout)
+        <*> fieldWith 32 "capacity" (view capacity)
 
 doesFileExist' :: FilePath -> IO (Maybe FilePath)
 doesFileExist' fn = do

--- a/literate-unitb-config/Z3/Version.hs
+++ b/literate-unitb-config/Z3/Version.hs
@@ -9,9 +9,10 @@ import Control.Precondition
 
 import Data.Bidirectional
 import Data.Char
+import Data.HashMap.Strict (empty)
 import Data.List as L
 import Data.List.Utils as L
-import Data.ConfigFile
+import Data.Yaml (Object, decodeFileEither)
 
 import GHC.Generics
 
@@ -81,7 +82,7 @@ z3_installed = do
     z3_bin <- doesFileExist z3_path
     return $ or (z3_bin : xs)
 
-config :: Lens' ConfigParser Z3Config
+config :: Lens' Object Z3Config
 config = lensOf $ Z3Config 
         <$> fieldWith "z3" "z3_path" (view z3Path)
         <*> fieldWith' 20 "timeout" (view z3Timeout)
@@ -105,9 +106,9 @@ defaultConfigPath = do
     return $ home </> configFileName
 
 configFileName :: FilePath
-configFileName = "z3_config.conf"
+configFileName = "z3_config.yml"
 
-getConfigFile :: IO (FilePath,ConfigParser)
+getConfigFile :: IO (FilePath, Object)
 getConfigFile = do
     path <- getExecutablePath
     def  <- defaultConfigPath
@@ -117,8 +118,8 @@ getConfigFile = do
             , path </> fn 
             , def ]
         >>= \case
-            Just fn' -> (fn',) . fromRight emptyCP <$> readfile emptyCP fn'
-            Nothing  -> return $ (def,emptyCP)
+            Just fn' -> (fn',) . fromRight empty <$> decodeFileEither fn'
+            Nothing  -> return $ (def, empty)
 
 z3_config :: Z3Config
 z3_config = unsafePerformIO $ do

--- a/literate-unitb-config/Z3/Version.hs
+++ b/literate-unitb-config/Z3/Version.hs
@@ -84,10 +84,10 @@ z3_installed = do
 
 config :: Lens' Object Z3Config
 config = lensOf $ Z3Config 
-        <$> fieldWith "z3" "z3_path" (view z3Path)
-        <*> fieldWith 20 "timeout" (view z3Timeout)
-        <*> fieldWith 3000 "default_timeout" (view z3DefaultTimeout)
-        <*> fieldWith 32 "capacity" (view capacity)
+        <$> fieldWith "z3_path"         "z3" (view z3Path)
+        <*> fieldWith "timeout"         20   (view z3Timeout)
+        <*> fieldWith "default_timeout" 3000 (view z3DefaultTimeout)
+        <*> fieldWith "capacity"        32   (view capacity)
 
 doesFileExist' :: FilePath -> IO (Maybe FilePath)
 doesFileExist' fn = do

--- a/literate-unitb-config/app/Options.hs
+++ b/literate-unitb-config/app/Options.hs
@@ -5,9 +5,9 @@ import Control.DeepSeq
 import Control.Exception
 import Control.Lens as L
 
-import Data.ConfigFile hiding (set)
 import Data.Maybe
 import Data.Monoid
+import Data.Yaml (encodeFile)
 
 import Options.Applicative 
 
@@ -53,7 +53,7 @@ rewriteConfig f = do
     let c' = f $ cp^.config
     homeSetting <- homeSettingPath
     createDirectoryIfMissing False homeSetting
-    writeFile fn $ to_string $ cp & config .~ c'
+    encodeFile fn $ cp & config .~ c'
     putStrLn "set the options to:"
     print c'
 

--- a/literate-unitb-config/app/Options.hs
+++ b/literate-unitb-config/app/Options.hs
@@ -74,4 +74,4 @@ main = execParser opts >>= apply
     where
         opts = info ( helper <*> commandLineOpts )
                 $   fullDesc
-                 <> header  "unitb-setting - customize the preferences for verifier"
+                 <> header  "unitb-config - customize the preferences for verifier"

--- a/literate-unitb-config/literate-unitb-config.cabal
+++ b/literate-unitb-config/literate-unitb-config.cabal
@@ -17,7 +17,7 @@ cabal-version:       >=1.10
 
 source-repository head
   type:     git
-  location: https://github.com/unitb/literate-unitb-config
+  location: https://github.com/unitb/literate-unitb-complete
 
 library
   exposed-modules:     Z3.Version, Data.Bidirectional, Utilities.Config
@@ -27,7 +27,7 @@ library
   hs-source-dirs:      .
   default-language:    Haskell2010
 
-executable unitb-option
+executable unitb-config
   -- .hs or .lhs file containing the Main module.
   main-is:  Options.hs
   hs-source-dirs: app

--- a/literate-unitb-config/literate-unitb-config.cabal
+++ b/literate-unitb-config/literate-unitb-config.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:     Z3.Version, Data.Bidirectional, Utilities.Config
   -- other-modules:       
   default-extensions:    LambdaCase, QuasiQuotes, TupleSections, FlexibleInstances, DeriveFunctor, RankNTypes, TemplateHaskell, DeriveGeneric
-  build-depends:       base >=4.7 && <5, lens >=4.12 && <4.16, transformers >=0.4 && <0.6, MissingH >=1.3 && <1.5, yaml >= 0.8.16, unordered-containers, text, directory >=1.2 && <1.4, filepath >=1.4 && <1.5, process >=1.2 && <1.6, control-invariants, th-printf, either, deepseq, pretty-printable
+  build-depends:       base >=4.7 && <5, lens >=4.12 && <4.16, transformers >=0.4 && <0.6, MissingH >=1.3 && <1.5, yaml >= 0.8.22, unordered-containers, text, directory >=1.2 && <1.4, filepath >=1.4 && <1.5, process >=1.2 && <1.6, control-invariants, th-printf, either, deepseq, pretty-printable
   hs-source-dirs:      .
   default-language:    Haskell2010
 
@@ -34,7 +34,7 @@ executable unitb-config
   default-language:    Haskell2010
 
     -- literate-unitb-scripts, 
-  build-depends:       base >=4.7 && < 5, directory >= 1.2.2.0, literate-unitb-config, optparse-applicative, yaml >= 0.8.16, lens, deepseq
+  build-depends:       base >=4.7 && < 5, directory >= 1.2.2.0, literate-unitb-config, optparse-applicative, yaml >= 0.8.22, lens, deepseq
 
   ghc-options: -W -fwarn-missing-signatures 
          -fwarn-incomplete-uni-patterns

--- a/literate-unitb-config/literate-unitb-config.cabal
+++ b/literate-unitb-config/literate-unitb-config.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:     Z3.Version, Data.Bidirectional, Utilities.Config
   -- other-modules:       
   default-extensions:    LambdaCase, QuasiQuotes, TupleSections, FlexibleInstances, DeriveFunctor, RankNTypes, TemplateHaskell, DeriveGeneric
-  build-depends:       base >=4.7 && <5, lens >=4.12 && <4.16, transformers >=0.4 && <0.6, MissingH >=1.3 && <1.5, ConfigFile >=1.1 && <1.2, directory >=1.2 && <1.4, filepath >=1.4 && <1.5, process >=1.2 && <1.6, control-invariants, th-printf, containers, either, deepseq, pretty-printable
+  build-depends:       base >=4.7 && <5, lens >=4.12 && <4.16, transformers >=0.4 && <0.6, MissingH >=1.3 && <1.5, yaml >= 0.8.16, unordered-containers, text, directory >=1.2 && <1.4, filepath >=1.4 && <1.5, process >=1.2 && <1.6, control-invariants, th-printf, containers, either, deepseq, pretty-printable
   hs-source-dirs:      .
   default-language:    Haskell2010
 
@@ -34,7 +34,7 @@ executable unitb-option
   default-language:    Haskell2010
 
     -- literate-unitb-scripts, 
-  build-depends:       base >=4.7 && < 5, directory >= 1.2.2.0, literate-unitb-config, optparse-applicative, ConfigFile, lens, deepseq
+  build-depends:       base >=4.7 && < 5, directory >= 1.2.2.0, literate-unitb-config, optparse-applicative, yaml >= 0.8.16, lens, deepseq
 
   ghc-options: -W -fwarn-missing-signatures 
          -fwarn-incomplete-uni-patterns

--- a/literate-unitb-config/literate-unitb-config.cabal
+++ b/literate-unitb-config/literate-unitb-config.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:     Z3.Version, Data.Bidirectional, Utilities.Config
   -- other-modules:       
   default-extensions:    LambdaCase, QuasiQuotes, TupleSections, FlexibleInstances, DeriveFunctor, RankNTypes, TemplateHaskell, DeriveGeneric
-  build-depends:       base >=4.7 && <5, lens >=4.12 && <4.16, transformers >=0.4 && <0.6, MissingH >=1.3 && <1.5, yaml >= 0.8.16, unordered-containers, text, directory >=1.2 && <1.4, filepath >=1.4 && <1.5, process >=1.2 && <1.6, control-invariants, th-printf, containers, either, deepseq, pretty-printable
+  build-depends:       base >=4.7 && <5, lens >=4.12 && <4.16, transformers >=0.4 && <0.6, MissingH >=1.3 && <1.5, yaml >= 0.8.16, unordered-containers, text, directory >=1.2 && <1.4, filepath >=1.4 && <1.5, process >=1.2 && <1.6, control-invariants, th-printf, either, deepseq, pretty-printable
   hs-source-dirs:      .
   default-language:    Haskell2010
 

--- a/stack-lts-3.yaml
+++ b/stack-lts-3.yaml
@@ -76,7 +76,7 @@ extra-deps:
 - portable-template-haskell-lens-0.1.0.0
 - zlib-0.6.1.0
 - quickcheck-text-0.1.2.1
-- yaml-0.8.16
+- yaml-0.8.22
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack-lts-3.yaml
+++ b/stack-lts-3.yaml
@@ -76,6 +76,7 @@ extra-deps:
 - portable-template-haskell-lens-0.1.0.0
 - zlib-0.6.1.0
 - quickcheck-text-0.1.2.1
+- yaml-0.8.16
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
A series of changes to the `literate-unitb-config` executable, `unitb-config`:

1. Swap out `ConfigFile` in favour of `yaml` for the configuration file. The configuration file was renamed from `z3_config.conf` to `z3_config.yml` to reflect the change.
2. Generalize functions of the `Document` type class to reduce duplication (with respect to `field`, `fieldWith`, and their primed variants) and to accommodate for introduction of `yaml`.
3. Rename the executable from `unitb-option` to `unitb-config` consistently.